### PR TITLE
Change `wd` from `Data` to `data`

### DIFF
--- a/08-FlightR.Rmd
+++ b/08-FlightR.Rmd
@@ -12,7 +12,7 @@ setupGeolocation()
 
 ```{r, warning=FALSE, message=FALSE}
 ID <- "M034"
-wd <- "Data"
+wd <- "data"
 Species <- "LanCol" 
 
 lon.calib <- 12.33


### PR DESCRIPTION
Dear developers,

This suggestion follows a help request from a user to our support team at the University of Groningen when transitioning from a Windows based laptop to our Linux HPC.

### Issue 
In chapter 8, a working directory is set to `Data/`, but the download directory is created as `data/`

### Consequence
If following from the instructions in chapter 1:

``` r
url <- "https://github.com/slisovski/TheGeolocationManual/raw/master/download.zip"

temp <- tempfile()
download.file(url, temp)
unzip(temp, exdir = "data")
```

This line in chapter 8 fails:
``` r
raw <- readMTlux(paste0(wd, "/RawData/", Species, "/", ID, ".lux"))

Error in file(file, "rt") : cannot open the connection
Calls: readMTlux -> read.table -> file
In addition: Warning message:
In file(file, "rt") :
cannot open file 'Data/RawData/LanCol/M034.lux': No such file or directory
```

### Cause and solution
The directory is not found in Linux systems because paths are case sensitive. This can be confusing for users, particularly if their local system is Windows based and hence the code works on their laptop, yet fails when run on Linux systems. My proposed solution changes the `wd` directory name to match that of the extracted archive.